### PR TITLE
Update ListLoggedInUsers() function to return also logon type

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	so "github.com/iamacarpet/go-win64api/shared"
+	so "github.com/fvitan/go-win64api/shared"
 )
 
 var (
@@ -96,6 +96,7 @@ func ListLoggedInUsers() ([]so.SessionDetails, error) {
 									Username:   strings.ToLower(LsatoString(data.UserName)),
 									Domain:     strLogonDomain,
 									LocalAdmin: isAdmin,
+									LogonType:  data.LogonType,
 								}
 								hn, _ := os.Hostname()
 								if strings.ToUpper(ud.Domain) == strings.ToUpper(hn) {

--- a/sessions.go
+++ b/sessions.go
@@ -97,6 +97,8 @@ func ListLoggedInUsers() ([]so.SessionDetails, error) {
 									Domain:     strLogonDomain,
 									LocalAdmin: isAdmin,
 									LogonType:  data.LogonType,
+									DnsDomainName: LsatoString(data.DnsDomainName),
+									LogonTime: data.LogonTime,
 								}
 								hn, _ := os.Hostname()
 								if strings.ToUpper(ud.Domain) == strings.ToUpper(hn) {

--- a/shared/session.go
+++ b/shared/session.go
@@ -5,11 +5,13 @@ import (
 )
 
 type SessionDetails struct {
-	Username   string `json:"username"`
-	Domain     string `json:"domain"`
-	LocalUser  bool   `json:"isLocal"`
-	LocalAdmin bool   `json:"isAdmin"`
-	LogonType  uint32 `json:"logonType"`
+	Username      string `json:"username"`
+	Domain        string `json:"domain"`
+	LocalUser     bool   `json:"isLocal"`
+	LocalAdmin    bool   `json:"isAdmin"`
+	LogonType     uint32 `json:"logonType"`
+	LogonTime     uint64 `json:"logonTime"`
+	DnsDomainName string `json:"dnsDomainName"`
 }
 
 func (s *SessionDetails) FullUser() string {

--- a/shared/session.go
+++ b/shared/session.go
@@ -1,16 +1,17 @@
 package shared
 
 import (
-    "fmt"
+	"fmt"
 )
 
 type SessionDetails struct {
-    Username                string          `json:"username"`
-    Domain                  string          `json:"domain"`
-    LocalUser               bool            `json:"isLocal"`
-    LocalAdmin              bool            `json:"isAdmin"`
+	Username   string `json:"username"`
+	Domain     string `json:"domain"`
+	LocalUser  bool   `json:"isLocal"`
+	LocalAdmin bool   `json:"isAdmin"`
+	LogonType  uint32 `json:"logonType"`
 }
 
-func (s *SessionDetails) FullUser() (string) {
-    return fmt.Sprintf("%s\\%s", s.Domain, s.Username)
+func (s *SessionDetails) FullUser() string {
+	return fmt.Sprintf("%s\\%s", s.Domain, s.Username)
 }


### PR DESCRIPTION
Updated the ListLoggedInUsers() function (and SessionDetails type) to return the logon type. This could be useful since we have three valid logon type: SESS_INTERACTIVE_LOGON, SESS_CACHED_INTERACTIVE_LOGON, SESS_REMOTE_INTERACTIVE_LOGON
