### PR TITLE
Fix wrong session with same name

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -77,7 +77,7 @@ func ListLoggedInUsers() ([]so.SessionDetails, error) {
 			var data *SECURITY_LOGON_SESSION_DATA = (*SECURITY_LOGON_SESSION_DATA)(unsafe.Pointer(sessionData))
 
 			if data.Sid != uintptr(0) {
-				validTypes := []uint32{so.SESS_INTERACTIVE_LOGON, so.SESS_CACHED_INTERACTIVE_LOGON, so.SESS_REMOTE_INTERACTIVE_LOGON}
+				validTypes := []uint32{so.SESS_CACHED_INTERACTIVE_LOGON, so.SESS_REMOTE_INTERACTIVE_LOGON}
 				if in_array(data.LogonType, validTypes) {
 					strLogonDomain := strings.ToUpper(LsatoString(data.LogonDomain))
 					if strLogonDomain != "WINDOW MANAGER" && strLogonDomain != "FONT DRIVER HOST" {


### PR DESCRIPTION
Hi, ive found that if user connect to Win by RDP (for example) with own login, and then evaluate some operation as Administrator with login and pass in evaluatew window, and then disconnect and reconnect again but with Administrator login aaand we can get wrong data (different than in cmd>qwinsta) in this case. SessionId for Administrator will be wrong in go-win64api case
 If you remove session.go:80 so.SESS_INTERACTIVE_LOGON you will get similar answer with qwinsta.
Sorry for my runglish)