### PR TITLE
Allow custom an Action when create new rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,5 +219,6 @@ added, err := wapi.FirewallRuleCreate(
 	"%systemDrive%\\path\\to\\my.exe",
 	"port number as string",
 	wapi.NET_FW_IP_PROTOCOL_TCP,
+        wapi.NET_FW_ACTION_ALLOW,
 )
 ```

--- a/firewall.go
+++ b/firewall.go
@@ -102,12 +102,12 @@ func (r *FWRule) InProfiles() FWProfiles {
 //   NET_FW_PROFILE2_CURRENT // adds rule to currently used FW Profile(-s)
 //   NET_FW_PROFILE2_ALL // adds rule to all profiles
 //   NET_FW_PROFILE2_DOMAIN|NET_FW_PROFILE2_PRIVATE // rule in Private and Domain profile
-func FirewallRuleAdd(name, description, group, ports string, protocol, profile int32) (bool, error) {
+func FirewallRuleAdd(name, description, group, ports string, protocol, action, profile int32) (bool, error) {
 
 	if ports == "" {
 		return false, fmt.Errorf("empty FW Rule ports, it is mandatory")
 	}
-	return firewallRuleAdd(name, description, group, "", "", ports, "", "", "", "", protocol, 0, profile, true, false)
+	return firewallRuleAdd(name, description, group, "", "", ports, "", "", "", "", protocol, 0, action, profile, true, false)
 }
 
 // FirewallRuleAddApplication creates Inbound rule for given application.
@@ -128,16 +128,16 @@ func FirewallRuleAdd(name, description, group, ports string, protocol, profile i
 //   NET_FW_PROFILE2_CURRENT // adds rule to currently used FW Profile
 //   NET_FW_PROFILE2_ALL // adds rule to all profiles
 //   NET_FW_PROFILE2_DOMAIN|NET_FW_PROFILE2_PRIVATE // rule in Private and Domain profile
-func FirewallRuleAddApplication(name, description, group, appPath string, profile int32) (bool, error) {
+func FirewallRuleAddApplication(name, description, group, appPath string, action, profile int32) (bool, error) {
 	if appPath == "" {
 		return false, fmt.Errorf("empty FW Rule appPath, it is mandatory")
 	}
-	return firewallRuleAdd(name, description, group, appPath, "", "", "", "", "", "", 0, 0, profile, true, false)
+	return firewallRuleAdd(name, description, group, appPath, "", "", "", "", "", "", 0, 0, action, profile, true, false)
 }
 
 // FirewallRuleCreate is deprecated, use FirewallRuleAddApplication instead.
-func FirewallRuleCreate(name, description, group, appPath, port string, protocol int32) (bool, error) {
-	return firewallRuleAdd(name, description, group, appPath, "", port, "", "", "", "", protocol, 0, NET_FW_PROFILE2_CURRENT, true, false)
+func FirewallRuleCreate(name, description, group, appPath, port string, protocol, action int32) (bool, error) {
+	return firewallRuleAdd(name, description, group, appPath, "", port, "", "", "", "", protocol, 0, action, NET_FW_PROFILE2_CURRENT, true, false)
 }
 
 // FirewallPingEnable creates Inbound ICMPv4 rule which allows to answer echo requests.
@@ -156,7 +156,7 @@ func FirewallRuleCreate(name, description, group, appPath, port string, protocol
 //   NET_FW_PROFILE2_ALL // adds rule to all profiles
 //   NET_FW_PROFILE2_DOMAIN|NET_FW_PROFILE2_PRIVATE // rule in Private and Domain profile
 func FirewallPingEnable(name, description, group, remoteAddresses string, profile int32) (bool, error) {
-	return firewallRuleAdd(name, description, group, "", "", "", "", "", remoteAddresses, "8:*", NET_FW_IP_PROTOCOL_ICMPv4, 0, profile, true, false)
+	return firewallRuleAdd(name, description, group, "", "", "", "", "", remoteAddresses, "8:*", NET_FW_IP_PROTOCOL_ICMPv4, 0, 1, profile, true, false)
 }
 
 // FirewallRuleAddAdvanced allows to modify almost all available FW Rule parameters.
@@ -167,7 +167,7 @@ func FirewallPingEnable(name, description, group, remoteAddresses string, profil
 func FirewallRuleAddAdvanced(rule FWRule) (bool, error) {
 	return firewallRuleAdd(rule.Name, rule.Description, rule.Grouping, rule.ApplicationName, rule.ServiceName,
 		rule.LocalPorts, rule.RemotePorts, rule.LocalAddresses, rule.RemoteAddresses, rule.ICMPTypesAndCodes,
-		rule.Protocol, rule.Direction, rule.Profiles, rule.Enabled, rule.EdgeTraversal)
+		rule.Protocol, rule.Direction, rule.Action, rule.Profiles, rule.Enabled, rule.EdgeTraversal)
 }
 
 // FirewallRuleDelete allows you to delete existing rule by name.
@@ -561,7 +561,7 @@ func firewallParseProfiles(v int32) FWProfiles {
 }
 
 // firewallRuleAdd is universal function to add all kinds of rules.
-func firewallRuleAdd(name, description, group, appPath, serviceName, ports, remotePorts, localAddresses, remoteAddresses, icmpTypes string, protocol, direction, profile int32, enabled, edgeTraversal bool) (bool, error) {
+func firewallRuleAdd(name, description, group, appPath, serviceName, ports, remotePorts, localAddresses, remoteAddresses, icmpTypes string, protocol, direction, action, profile int32, enabled, edgeTraversal bool) (bool, error) {
 
 	if name == "" {
 		return false, fmt.Errorf("empty FW Rule name, name is mandatory")
@@ -667,7 +667,7 @@ func firewallRuleAdd(name, description, group, appPath, serviceName, ports, remo
 	if _, err := oleutil.PutProperty(fwRule, "Profiles", profile); err != nil {
 		return false, fmt.Errorf("Error setting property (Profiles) of Rule: %s", err)
 	}
-	if _, err := oleutil.PutProperty(fwRule, "Action", NET_FW_ACTION_ALLOW); err != nil {
+	if _, err := oleutil.PutProperty(fwRule, "Action", action); err != nil {
 		return false, fmt.Errorf("Error setting property (Action) of Rule: %s", err)
 	}
 	if edgeTraversal {

--- a/firewall_examples_test.go
+++ b/firewall_examples_test.go
@@ -9,7 +9,7 @@ import (
 
 func ExampleFirewallRuleAdd() {
 	ok, err := FirewallRuleAdd("SQL Server", "Main static SQL Server port 1433", "SQL services", "1433",
-		NET_FW_IP_PROTOCOL_TCP, NET_FW_PROFILE2_DOMAIN|NET_FW_PROFILE2_PRIVATE)
+		NET_FW_IP_PROTOCOL_TCP, NET_FW_ACTION_ALLOW, NET_FW_PROFILE2_DOMAIN|NET_FW_PROFILE2_PRIVATE)
 	if ok {
 		fmt.Println("Firewall rule created!")
 	} else {
@@ -23,7 +23,7 @@ func ExampleFirewallRuleAdd() {
 
 func ExampleFirewallRuleAddApplication() {
 	_, err := FirewallRuleAddApplication("SQL Browser App", "App rule for SQL Browser", "SQL Services",
-		`%ProgramFiles% (x86)\Microsoft SQL Server\90\Shared\sqlbrowser.exe`, NET_FW_PROFILE2_CURRENT)
+		`%ProgramFiles% (x86)\Microsoft SQL Server\90\Shared\sqlbrowser.exe`, NET_FW_ACTION_ALLOW, NET_FW_PROFILE2_CURRENT)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -64,6 +64,7 @@ func ExampleFirewallRuleAddAdvanced_iPv6Ping() {
 		Grouping:          "My group",
 		Enabled:           true,
 		Protocol:          NET_FW_IP_PROTOCOL_ICMPv6,
+		Action:            NET_FW_ACTION_ALLOW,
 		ICMPTypesAndCodes: "128:*", // https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml
 	}
 
@@ -95,6 +96,7 @@ func ExampleFirewallRuleAddAdvanced_restrictedLocalPorts() {
 		Protocol:        NET_FW_IP_PROTOCOL_TCP,
 		LocalPorts:      "1234",
 		ApplicationName: `C:\Test\myApp`,
+		Action:          NET_FW_ACTION_ALLOW,
 		Profiles:        NET_FW_PROFILE2_PRIVATE | NET_FW_PROFILE2_DOMAIN, // let's enable it in 2 profiles
 	}
 
@@ -125,6 +127,7 @@ func ExampleFirewallRuleAddAdvanced_serviceRule() {
 		Enabled:     true,
 		Protocol:    NET_FW_IP_PROTOCOL_ANY,
 		ServiceName: "SQLBrowser",
+		Action:      NET_FW_ACTION_ALLOW,
 		Profiles:    NET_FW_PROFILE2_CURRENT, // let's enable it in currently used profiles
 	}
 

--- a/firewall_test.go
+++ b/firewall_test.go
@@ -49,7 +49,7 @@ func TestCreatingRule(t *testing.T) {
 	rule.LocalAddresses = "*"
 	rule.InterfaceTypes = "All"
 	rule.ApplicationName = ""
-	ok, err := FirewallRuleAdd(rule.Name, rule.Description, rule.Grouping, rule.LocalPorts, rule.Protocol, rule.Profiles)
+	ok, err := FirewallRuleAdd(rule.Name, rule.Description, rule.Grouping, rule.LocalPorts, rule.Protocol, rule.Action, rule.Profiles)
 	if !ok {
 		if err != nil {
 			t.Errorf("problem with adding FW rule: %v", err)
@@ -73,7 +73,7 @@ func TestFirewallRuleAddApplication(t *testing.T) {
 	rule.LocalAddresses = "*"
 	rule.InterfaceTypes = "All"
 	rule.Protocol = NET_FW_IP_PROTOCOL_ANY
-	ok, err := FirewallRuleAddApplication(rule.Name, rule.Description, rule.Grouping, rule.ApplicationName, rule.Profiles)
+	ok, err := FirewallRuleAddApplication(rule.Name, rule.Description, rule.Grouping, rule.ApplicationName, rule.Action, rule.Profiles)
 	if !ok {
 		if err != nil {
 			t.Errorf("problem with adding FW application rule: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
-module github.com/iamacarpet/go-win64api
+module github.com/mrpk1906/go-win64api
 
-go 1.13
+go 1.15
 
 require (
 	github.com/go-ole/go-ole v1.2.4
+	github.com/iamacarpet/go-win64api v0.0.0-20200715182619-8cbc936e1a5a
 	golang.org/x/sys v0.0.0-20200622182413-4b0db7f3f76b
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
+github.com/iamacarpet/go-win64api v0.0.0-20200715182619-8cbc936e1a5a h1:PotlHkUHYTVAjZTW1HbXw43luragnCAI0XzyZ5Tek3k=
+github.com/iamacarpet/go-win64api v0.0.0-20200715182619-8cbc936e1a5a/go.mod h1:oGJx9dz0Ny7HC7U55RZ0Smd6N9p3hXP/+hOFtuYrAxM=
 golang.org/x/sys v0.0.0-20200622182413-4b0db7f3f76b h1:K/lGZjl2fciTddokWoFMrsvKYoudTOUiqj7yfBHYIZk=
 golang.org/x/sys v0.0.0-20200622182413-4b0db7f3f76b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Allow set an Action when create new rule

```go
...
// add new rule
rule := wapi.FWRule{
	Name:            ruleName,
	Description:     "Inbound rule to block IP ranges from Spamhaus",
	Grouping:        "Security Agent",
	InterfaceTypes:  "All",
	Protocol:        wapi.NET_FW_IP_PROTOCOL_ANY,
	LocalAddresses:  "*",
	RemoteAddresses: strings.Join(ipBlocks, ","),
	Direction:       wapi.NET_FW_RULE_DIR_IN,
	Action:          wapi.NET_FW_ACTION_BLOCK,
	Profiles:        wapi.NET_FW_PROFILE2_ALL,
	Enabled:         true,
	EdgeTraversal:   false,
}
_, err = wapi.FirewallRuleAddAdvanced(rule)
...
```