### PR TITLE
Update BitLockerConversionStatus type & add constants

### DIFF
--- a/bitlocker.go
+++ b/bitlocker.go
@@ -259,15 +259,17 @@ func bitlockerConversionStatus(result *ole.IDispatch, i int) (*so.BitLockerConve
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get conversion status while getting BitLocker info: %w", err)
-	} else if val, ok := statusResultRaw.Value().(int32); val != 0 || !ok {
-		return nil, fmt.Errorf("unable to get conversion status while getting BitLocker info. Return code %d", val)
+	} else if val, ok := statusResultRaw.Value().(uint32); val != 0 || !ok {
+		// The possible return values of GetConversionStatus are S_OK (0x0) and FVE_E_LOCKED_VOLUME (0x80310000)
+		// If the return value is not 0, the volume is locked.
+		return nil, fmt.Errorf("unable to get conversion status while getting BitLocker info; the volume is locked. Return code %d", val)
 	}
 
-	retData.ConversionStatus = conversionStatus.Value().(int32)
-	retData.EncryptionPercentage = encryptionPercentage.Value().(int32)
-	retData.EncryptionFlags = encryptionFlags.Value().(int32)
-	retData.WipingStatus = wipingStatus.Value().(int32)
-	retData.WipingPercentage = wipingPercentage.Value().(int32)
+	retData.ConversionStatus = conversionStatus.Value().(uint32)
+	retData.EncryptionPercentage = encryptionPercentage.Value().(uint32)
+	retData.EncryptionFlags = encryptionFlags.Value().(uint32)
+	retData.WipingStatus = wipingStatus.Value().(uint32)
+	retData.WipingPercentage = wipingPercentage.Value().(uint32)
 
 	return retData, nil
 }

--- a/shared/bitlocker.go
+++ b/shared/bitlocker.go
@@ -2,12 +2,37 @@ package shared
 
 // BitLockerConversionStatus represents the GetConversionStatus method of Win32_EncryptableVolume
 type BitLockerConversionStatus struct {
-	ConversionStatus     int32
-	EncryptionPercentage int32
-	EncryptionFlags      int32
-	WipingStatus         int32
-	WipingPercentage     int32
+	ConversionStatus     uint32
+	EncryptionPercentage uint32
+	EncryptionFlags      uint32
+	WipingStatus         uint32
+	WipingPercentage     uint32
 }
+
+// Possible values for the value placed in the ConversionStatus field returned by the GetConversionStatus method of Win32_EncryptableVolume
+const (
+	FULLY_DECRYPTED = iota
+	FULLY_ENCRYPTED
+	ENCRYPTION_IN_PROGRESS
+	DECRYPTION_IN_PROGRESS
+	ENCRYPTION_PAUSED
+	DECRYPTION_PAUSED
+)
+
+// Bitflags for the value placed in the EncryptionFlags field returned by the GetConversionStatus method of Win32_EncryptableVolume
+const (
+	DATA_ONLY      = 0x00000001
+	ON_DEMAND_WIPE = 0x00000002
+	SYNCHRONOUS    = 0x00010000
+)
+
+// Possible values for the value placed in the WipingStatus field returned by the GetConversionStatus method of Win32_EncryptableVolume
+const (
+	NOT_WIPED = iota
+	WIPED
+	WIPING_IN_PROGRESS
+	WIPING_PAUSED
+)
 
 // BitLockerDeviceInfo contains the bitlocker state for a given device
 type BitLockerDeviceInfo struct {


### PR DESCRIPTION
The `BitLockerConversionStatus` struct represents the GetConversonStatus method specified at https://docs.microsoft.com/en-us/windows/win32/secprov/getconversionstatus-win32-encryptablevolume. However, the documentation states that the fields should be unsigned 32-bit integers, so I corrected the struct and the function that returns it accordingly. Additionally, I added constants to make comparing the fields to certain values easier.