### PR TITLE
add a non-windows build stub

### DIFF
--- a/stub.go
+++ b/stub.go
@@ -1,0 +1,6 @@
+//go:build !windows
+// +build !windows
+
+package winapi
+
+// This stub allows the winapi package to be imported by non-Windows builds (minus most package functionality).


### PR DESCRIPTION
Entirely windows-only packages like winapi can pose a dependency problem when importing into cross-platform code. Adding a stub file for non-windows builds makes the package a valid import in these cases. The function signatures will be missing on other platforms, although they can also be added here if needed in the future.