### PR TITLE
Fix: Custom action not considered in FirewallRuleAddAdvanced

### DIFF
--- a/firewall.go
+++ b/firewall.go
@@ -109,7 +109,7 @@ func FirewallRuleAdd(name, description, group, ports string, protocol, profile i
 	if ports == "" {
 		return false, fmt.Errorf("empty FW Rule ports, it is mandatory")
 	}
-	return firewallRuleAdd(name, description, group, "", "", ports, "", "", "", "", protocol, 0, profile, true, false)
+	return firewallRuleAdd(name, description, group, "", "", ports, "", "", "", "", protocol, 0, NET_FW_ACTION_ALLOW, profile, true, false)
 }
 
 // FirewallRuleAddApplication creates Inbound rule for given application.
@@ -134,12 +134,12 @@ func FirewallRuleAddApplication(name, description, group, appPath string, profil
 	if appPath == "" {
 		return false, fmt.Errorf("empty FW Rule appPath, it is mandatory")
 	}
-	return firewallRuleAdd(name, description, group, appPath, "", "", "", "", "", "", 0, 0, profile, true, false)
+	return firewallRuleAdd(name, description, group, appPath, "", "", "", "", "", "", 0, 0, NET_FW_ACTION_ALLOW, profile, true, false)
 }
 
 // FirewallRuleCreate is deprecated, use FirewallRuleAddApplication instead.
 func FirewallRuleCreate(name, description, group, appPath, port string, protocol int32) (bool, error) {
-	return firewallRuleAdd(name, description, group, appPath, "", port, "", "", "", "", protocol, 0, NET_FW_PROFILE2_CURRENT, true, false)
+	return firewallRuleAdd(name, description, group, appPath, "", port, "", "", "", "", protocol, 0, NET_FW_ACTION_ALLOW, NET_FW_PROFILE2_CURRENT, true, false)
 }
 
 // FirewallPingEnable creates Inbound ICMPv4 rule which allows to answer echo requests.
@@ -158,7 +158,7 @@ func FirewallRuleCreate(name, description, group, appPath, port string, protocol
 //   NET_FW_PROFILE2_ALL // adds rule to all profiles
 //   NET_FW_PROFILE2_DOMAIN|NET_FW_PROFILE2_PRIVATE // rule in Private and Domain profile
 func FirewallPingEnable(name, description, group, remoteAddresses string, profile int32) (bool, error) {
-	return firewallRuleAdd(name, description, group, "", "", "", "", "", remoteAddresses, "8:*", NET_FW_IP_PROTOCOL_ICMPv4, 0, profile, true, false)
+	return firewallRuleAdd(name, description, group, "", "", "", "", "", remoteAddresses, "8:*", NET_FW_IP_PROTOCOL_ICMPv4, 0, NET_FW_ACTION_ALLOW, profile, true, false)
 }
 
 // FirewallRuleAddAdvanced allows to modify almost all available FW Rule parameters.
@@ -169,7 +169,7 @@ func FirewallPingEnable(name, description, group, remoteAddresses string, profil
 func FirewallRuleAddAdvanced(rule FWRule) (bool, error) {
 	return firewallRuleAdd(rule.Name, rule.Description, rule.Grouping, rule.ApplicationName, rule.ServiceName,
 		rule.LocalPorts, rule.RemotePorts, rule.LocalAddresses, rule.RemoteAddresses, rule.ICMPTypesAndCodes,
-		rule.Protocol, rule.Direction, rule.Profiles, rule.Enabled, rule.EdgeTraversal)
+		rule.Protocol, rule.Direction, rule.Action, rule.Profiles, rule.Enabled, rule.EdgeTraversal)
 }
 
 // FirewallRuleDelete allows you to delete existing rule by name.
@@ -577,7 +577,7 @@ func firewallParseProfiles(v int32) FWProfiles {
 }
 
 // firewallRuleAdd is universal function to add all kinds of rules.
-func firewallRuleAdd(name, description, group, appPath, serviceName, ports, remotePorts, localAddresses, remoteAddresses, icmpTypes string, protocol, direction, profile int32, enabled, edgeTraversal bool) (bool, error) {
+func firewallRuleAdd(name, description, group, appPath, serviceName, ports, remotePorts, localAddresses, remoteAddresses, icmpTypes string, protocol, direction, action, profile int32, enabled, edgeTraversal bool) (bool, error) {
 
 	if name == "" {
 		return false, fmt.Errorf("empty FW Rule name, name is mandatory")
@@ -683,7 +683,7 @@ func firewallRuleAdd(name, description, group, appPath, serviceName, ports, remo
 	if _, err := oleutil.PutProperty(fwRule, "Profiles", profile); err != nil {
 		return false, fmt.Errorf("Error setting property (Profiles) of Rule: %s", err)
 	}
-	if _, err := oleutil.PutProperty(fwRule, "Action", NET_FW_ACTION_ALLOW); err != nil {
+	if _, err := oleutil.PutProperty(fwRule, "Action", action); err != nil {
 		return false, fmt.Errorf("Error setting property (Action) of Rule: %s", err)
 	}
 	if edgeTraversal {


### PR DESCRIPTION
`FirewallRuleAddAdvanced` takes a `FWRule` struct which has an `Action` parameter. But this parameter is not considered, the action will always be "allow". 

The fix adds a new parameter `action` to the internal function `firewallRuleAdd`, leaving public APIs untouched. The default action is always `NET_FW_ACTION_ALLOW`, if not specified by `FWRule`. 

This PR can be seen as an API-preserving version of #35 . 